### PR TITLE
Task 3 - Both players on goal tile.

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -21,6 +21,7 @@ public class GameManager : MonoBehaviour
     private int steps = 0;
 
     private int[] maxSteps = { 30, 30, 30, 30 };
+    public static int NUM_LEVELS = 6;
 
 
     //Awake is always called before any Start functions
@@ -129,17 +130,38 @@ public class GameManager : MonoBehaviour
     public void setKnightOnGoalTile(bool b)
     {
         knightOnGoalTile = b;
+        goalsReached();
     }
 
     public void setGhostOnGoalTile(bool b)
     {
         ghostOnGoalTile = b;
+        goalsReached();
     }
 
-    private bool goalsReached()
+    private void goalsReached()
     {
-        //default
-        return false;
+        if(knightOnGoalTile && ghostOnGoalTile)
+        {
+            if(level != 6)
+            {
+                level++;
+                switchSpawnAndGoal();
+                disablePlayersMovement();
+                levelLoader.transitionToLevel(level);
+                StartCoroutine(waitBeforeEnableMovement());
+            }
+            else if (level == 7)
+            {
+                GameOver();
+            }
+        }
+    }
+
+    IEnumerator waitBeforeEnableMovement()
+    {
+        yield return new WaitForSecondsRealtime(10);
+        enablePlayersMovement();
     }
 
     private void switchSpawnAndGoal()

--- a/Assets/Scripts/GhostMovTileBased.cs
+++ b/Assets/Scripts/GhostMovTileBased.cs
@@ -26,6 +26,8 @@ public class GhostMovTileBased : MonoBehaviour
 
     Quaternion m_quaternion;
 
+    private Collider[] colliders;
+
     // Use this for initialization
     void Start()
     {
@@ -108,7 +110,7 @@ public class GhostMovTileBased : MonoBehaviour
     private void FixedUpdate()
     {
         m_grounded = false;
-        Collider[] colliders = Physics.OverlapSphere(m_GroundCheck.position, k_GroundedRadius);
+        colliders = Physics.OverlapSphere(m_GroundCheck.position, k_GroundedRadius);
 
         for (int i = 0; i < colliders.Length; i++)
         {
@@ -242,8 +244,16 @@ public class GhostMovTileBased : MonoBehaviour
 
     private void UpdateSteps()
     {
-        
-        //m_gameManager.GetComponent<GameManager>().IncrementSteps();
+
+        GameManager.instance.incrementSteps();
+        foreach (Collider c in colliders)
+        {
+            if (c.gameObject.tag == "goalTile")
+            {
+                GameManager.instance.setGhostOnGoalTile(true);
+            }
+        }
+                    
     }
 
     public void disableMovement()

--- a/Assets/Scripts/KnightMovTileBased.cs
+++ b/Assets/Scripts/KnightMovTileBased.cs
@@ -25,6 +25,8 @@ public class KnightMovTileBased : MonoBehaviour {
     GameManager m_gameManager;
     Quaternion m_quaternion;
 
+    private Collider[] colliders;
+
     // Use this for initialization
     void Start() {
         my_rigid_body = GetComponent<Rigidbody>();
@@ -110,7 +112,7 @@ public class KnightMovTileBased : MonoBehaviour {
     private void FixedUpdate()
     {
         m_grounded = false;
-        Collider[] colliders = Physics.OverlapSphere(m_GroundCheck.position, k_GroundedRadius);
+        colliders = Physics.OverlapSphere(m_GroundCheck.position, k_GroundedRadius);
 
         for (int i = 0; i < colliders.Length; i++)
         {
@@ -244,8 +246,14 @@ public class KnightMovTileBased : MonoBehaviour {
 
     private void UpdateSteps()
     {
-
-        m_gameManager.GetComponent<GameManager>().incrementSteps();
+        GameManager.instance.incrementSteps();
+        foreach (Collider c in colliders)
+        {
+            if (c.gameObject.tag == "goalTile")
+            {
+                GameManager.instance.setKnightOnGoalTile(true);
+            }
+        }
     }
 
     public void disableMovement()


### PR DESCRIPTION
SetKnightOnGoalTile
- calls goalsReached() after variable assignment.
SetGhostOnGoalTile
- calls goalsReached() after variable assignment.
goalsReached()
- if both on goal tile and not at the last level.
- - load the next level.
- else if at the end of all levels.
- - gameOver().
New method IENumerator waitBeforeEnableMovement()
- used to have the game wait an appropriate amount of time before allowing the players to move again.

KnightMovTileBased & GhostMovTileBased
- UpdateSteps()
- - if on a goal tile, call the appropriate bool setter in gameManager.